### PR TITLE
Fixed EditTransaction bug

### DIFF
--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -63,7 +63,7 @@ const EditTransactionModal: React.FC<EditTransactionModalProps> = ({
         setEditedTransaction({...editedTransaction, heading: event.target.value});
     }
     const handleAmountChange = (event: any) => {
-        setEditedTransaction({...editedTransaction, amount: event.target.value});
+        setEditedTransaction({...editedTransaction, amount: parseInt(event.target.value)});
     }
     const handleTypeChange = (event: any) => {
         // setEditedTransaction({...editedTransaction, type: event.target.value});


### PR DESCRIPTION
- the amount was getting set with string since
- event.target.value type is string I though the input type number
- would have number type but its only when we send the request number
- type is send