### PR TITLE
Storing transactions in local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
+    "redux": "^4.0.5",
     "redux-devtools": "^3.7.0",
     "redux-devtools-extension": "^2.13.8",
     "redux-persist": "^6.0.0",

--- a/src/components/Transactions.jsx
+++ b/src/components/Transactions.jsx
@@ -57,6 +57,19 @@ export default function Transactions({userId}) {
   const loadTransactions = useCallback(
     async () => {
       try {
+        // If there are transactions in store or if its not first day of month
+        // then no need to load transactions
+        // implies we need to refresh the store if its first day of month
+        // also we need to refresh the store if a new user is logged in
+        // or user deletes the local storage data
+        // local storage is better since I am sure that in a month
+        // the user will not store data more than 5MB
+        // also got a overview from adding so many transactions still the value didn't cross even 1MB
+
+        if (storeTransactions.length !== 0 && new Date().getDate() !== 1) {
+          setLoader(false);
+          return;
+        }
         const response = await fetch(url.API_URL_GET_TRANSACTIONS, {
           method: 'POST',
           headers: {
@@ -97,12 +110,12 @@ export default function Transactions({userId}) {
         setOffline(true);
       }
     },
-    [dispatch, setLoader, userId],
+      [dispatch, setLoader, userId, storeTransactions],
   );
   useEffect(() => {
-    // const user
     loadTransactions();
   }, [loadTransactions]);
+
   transactions.sort(sortTransactionsByDate);
 
   const date = new Date();

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,22 +11,19 @@ const rootPersistConfig = {
   whitelist: [],
 };
 
-// const transactionsPersistConfig = {
-//   key: 'transactions',
-//   storage,
-//   blacklist: ['status'],
-// };
+const transactionsPersistConfig = {
+  key: 'transactions',
+  storage,
+  blacklist: ['status']
+};
 const userPersistConfig = {
   key: 'user',
   storage,
-  // whitelist: ['userLoggedIn', 'userDetails'],
 };
 
 const rootReducer = combineReducers({
-  // transactions: persistReducer(transactionsPersistConfig, transactions),
-  transactions,
+  transactions: persistReducer(transactionsPersistConfig, transactions),
   user: persistReducer(userPersistConfig, user),
-  // import { composeWithDevTools } from 'redux-devtools-extension';
 });
 
 const persistedReducer = persistReducer(rootPersistConfig, rootReducer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9731,7 +9731,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.0:
+redux@^4.0.0, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
- Aim is to give as much possible offline experience
- Get request to fetch the transactions will be called only if user logs in first time or its first day of month or user clears the application data
- Using redux persist to store the transactions in local storage
- Have added status in blacklist since its the snack bar feedback shows the previous status text on refresh which is not needed
- Added redux package