### PR TITLE
issue-10-fixed-bug-in-transaction-analysis-page

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -73,7 +73,7 @@ export function createTransactionsGroupedByCategories (
         }
     });
     transactions.forEach((transaction) => {
-        if (transaction.category === '' || transaction.category === undefined) {
+        if (transaction.category === undefined) {
             // @ts-ignore
             transactionsGroupedByCategories['No Category']['transactions'].push(transaction);
             transactionsGroupedByCategories['No Category'].totalAmount += transaction.amount;


### PR DESCRIPTION
- had added category state empty string in add transaction modal previous commit
- and in show analysis page was checking if category was undefined then add it to No Category
- changed the logic to if category is empty string then too add it to No Category