### PR TITLE
issue-13-fix-transaction-card-height-when-multiline-content-is-added #57

### DIFF
--- a/src/components/TransactionCard/index.tsx
+++ b/src/components/TransactionCard/index.tsx
@@ -27,8 +27,8 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         })}
         onClick={handleClickOpen}
       >
-        <p>{heading}</p>
-        <p>{amount}</p>
+        <p className={styles.title}>{heading}</p>
+        <p className={styles.amount}>{amount}</p>
       </div>
       {open && <EditTransactionModal transaction={transaction} handleClose={handleClose} />}
     </>

--- a/src/components/TransactionCard/styles.module.scss
+++ b/src/components/TransactionCard/styles.module.scss
@@ -1,5 +1,4 @@
 .transactionCard {
-  height: 40px;
   margin-bottom: 5px;
   padding: 5px;
   display: flex;
@@ -8,8 +7,19 @@
   border-bottom: 1px solid grey;
   border-radius: 2px;
   font-size: 20px;
-}
 
+  & .title {
+    margin: 0;
+    width: 70%;
+    overflow: scroll;
+  }
+
+  & .amount {
+    margin: 0;
+    width: 20%;
+    text-align: end;
+  }
+}
 
 .transactionCardCredit {
   font-size: 22px;


### PR DESCRIPTION
- Gave specific width to title and amount of transaction card
- If title crosses width set it to overflow
- refactored css to use nested selectors